### PR TITLE
Add useful features for APS

### DIFF
--- a/hwsecurity/core/src/main/java/de/cotech/hw/internal/transport/nfc/NfcConnectionDispatcher.java
+++ b/hwsecurity/core/src/main/java/de/cotech/hw/internal/transport/nfc/NfcConnectionDispatcher.java
@@ -131,7 +131,11 @@ public class NfcConnectionDispatcher {
             throw new IllegalStateException("Method must not be called if nfcAdapter is null!");
         }
         Intent intent = new Intent(activity, activity.getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        PendingIntent tagIntent = PendingIntent.getActivity(activity, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        int flags = PendingIntent.FLAG_CANCEL_CURRENT;
+        if (Build.VERSION.SDK_INT >= 31) {
+            flags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+        PendingIntent tagIntent = PendingIntent.getActivity(activity, 0, intent, flags);
         IntentFilter tag = new IntentFilter(NfcAdapter.ACTION_TECH_DISCOVERED);
         nfcAdapter.enableForegroundDispatch(activity, tagIntent, new IntentFilter[] { tag },
                 new String[][] { new String[] { IsoDep.class.getName() } });

--- a/hwsecurity/core/src/main/java/de/cotech/hw/internal/transport/usb/UsbConnectionDispatcher.java
+++ b/hwsecurity/core/src/main/java/de/cotech/hw/internal/transport/usb/UsbConnectionDispatcher.java
@@ -33,6 +33,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 
 import androidx.annotation.AnyThread;
 import androidx.annotation.RestrictTo;
@@ -162,7 +163,11 @@ public class UsbConnectionDispatcher {
 
         Intent answerBroadcastIntent = new Intent(ACTION_USB);
         answerBroadcastIntent.setPackage(context.getApplicationInfo().packageName);
-        PendingIntent answerPendingIntent = PendingIntent.getBroadcast(context, 0, answerBroadcastIntent, 0);
+        int flags = 0;
+        if (Build.VERSION.SDK_INT >= 31) {
+            flags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+        PendingIntent answerPendingIntent = PendingIntent.getBroadcast(context, 0, answerBroadcastIntent, flags);
 
         HwTimber.d("Requesting permission for %s", usbDevice.getDeviceName());
         usbManager.requestPermission(usbDevice, answerPendingIntent);

--- a/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/OpenPgpSecurityKey.java
+++ b/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/OpenPgpSecurityKey.java
@@ -234,7 +234,9 @@ public class OpenPgpSecurityKey extends SecurityKey {
 
                 openPgpAppletConnection.refreshConnectionCapabilities();
 
-                return new PairedSecurityKey(getOpenPgpInstanceAid(),
+                return new PairedSecurityKey(getSecurityKeyName(),
+                        getSerialNumber(),
+                        getOpenPgpInstanceAid(),
                         encryptFingerprint, encryptKeyPair.getPublic(),
                         signFingerprint, signKeyPair.getPublic(),
                         authFingerprint, authKeyPair.getPublic()
@@ -249,7 +251,9 @@ public class OpenPgpSecurityKey extends SecurityKey {
 
                 openPgpAppletConnection.refreshConnectionCapabilities();
 
-                return new PairedSecurityKey(getOpenPgpInstanceAid(),
+                return new PairedSecurityKey(getSecurityKeyName(),
+                        getSerialNumber(),
+                        getOpenPgpInstanceAid(),
                         encryptFingerprint, encryptKeyPair.getPublic(),
                         null, null,
                         null, null
@@ -298,7 +302,9 @@ public class OpenPgpSecurityKey extends SecurityKey {
         byte[] signFingerprint = openPgpAppletConnection.getOpenPgpCapabilities().getFingerprintSign();
         byte[] authFingerprint = openPgpAppletConnection.getOpenPgpCapabilities().getFingerprintAuth();
 
-        return new PairedSecurityKey(getOpenPgpInstanceAid(),
+        return new PairedSecurityKey(getSecurityKeyName(),
+                getSerialNumber(),
+                getOpenPgpInstanceAid(),
                 encryptFingerprint, encryptPublicKey,
                 signFingerprint, signPublicKey,
                 authFingerprint, authPublicKey

--- a/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/OpenPgpSecurityKey.java
+++ b/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/OpenPgpSecurityKey.java
@@ -167,6 +167,28 @@ public class OpenPgpSecurityKey extends SecurityKey {
     }
 
     /**
+     * Pair a connected security key without wiping its state.
+     */
+    @WorkerThread
+    public PairedSecurityKey pairExistingKey() throws IOException {
+        PublicKey encryptPublicKey = retrievePublicKey(KeyType.ENCRYPT);
+        PublicKey signPublicKey = retrievePublicKey(KeyType.SIGN);
+        PublicKey authPublicKey = retrievePublicKey(KeyType.AUTH);
+
+        byte[] encryptFingerprint = openPgpAppletConnection.getOpenPgpCapabilities().getFingerprintEncrypt();
+        byte[] signFingerprint = openPgpAppletConnection.getOpenPgpCapabilities().getFingerprintSign();
+        byte[] authFingerprint = openPgpAppletConnection.getOpenPgpCapabilities().getFingerprintAuth();
+
+        return new PairedSecurityKey(getSecurityKeyName(),
+                getSerialNumber(),
+                getOpenPgpInstanceAid(),
+                encryptFingerprint, encryptPublicKey,
+                signFingerprint, signPublicKey,
+                authFingerprint, authPublicKey
+        );
+    }
+
+    /**
      * This methods sets up the connected security key for signing, encryption, and authentication.
      *
      * <ol>

--- a/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/pairedkey/PairedSecurityKey.java
+++ b/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/pairedkey/PairedSecurityKey.java
@@ -56,6 +56,8 @@ import androidx.annotation.RestrictTo.Scope;
 public class PairedSecurityKey implements Serializable {
     private static final long serialVersionUID = 1573018456341217789L;
 
+    private final String name;
+    private final String serialNumber;
     private final byte[] securityKeyAid;
     private final byte[] encryptFingerprint;
     private final PublicKey encryptPublicKey;
@@ -70,10 +72,12 @@ public class PairedSecurityKey implements Serializable {
      * This method should only be used internally.
      */
     @RestrictTo(Scope.LIBRARY_GROUP)
-    public PairedSecurityKey(byte[] securityKeyAid,
+    public PairedSecurityKey(String name, String serialNumber, byte[] securityKeyAid,
             byte[] encryptFingerprint, PublicKey encryptPublicKey,
             byte[] signFingerprint, PublicKey signPublicKey,
             byte[] authFingerprint, PublicKey authPublicKey) {
+        this.name = name;
+        this.serialNumber = serialNumber;
         this.securityKeyAid = securityKeyAid;
         this.encryptFingerprint = encryptFingerprint;
         this.encryptPublicKey = encryptPublicKey;
@@ -82,6 +86,16 @@ public class PairedSecurityKey implements Serializable {
         this.authFingerprint = authFingerprint;
         this.authPublicKey = authPublicKey;
     }
+
+    /**
+     * Returns the security key's user-identifiable name.
+     */
+    public String getName() { return name; }
+
+    /**
+     * Returns the security key's serial number.
+     */
+    public String getSerialNumber() { return serialNumber; }
 
     /**
      * Returns the security key's AID (Application Identifier).

--- a/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/storage/AndroidPreferencePairedSecurityKeyStorage.java
+++ b/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/storage/AndroidPreferencePairedSecurityKeyStorage.java
@@ -99,6 +99,14 @@ public class AndroidPreferencePairedSecurityKeyStorage implements PairedSecurity
                 .apply();
     }
 
+    @Override
+    public void deletePairedSecurityKey(byte[] aid) {
+        String securityKeyPrefKey = getPrefKeyForSecurityKeyAid(aid);
+        sharedPreferences.edit()
+                .remove(securityKeyPrefKey)
+                .apply();
+    }
+
     private String getPrefKeyForSecurityKeyAid(byte[] securityKeyAid) {
         return PREF_PREFIX + Hex.encodeHexString(securityKeyAid);
     }

--- a/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/storage/PairedSecurityKeyStorage.java
+++ b/hwsecurity/openpgp/src/main/java/de/cotech/hw/openpgp/storage/PairedSecurityKeyStorage.java
@@ -49,4 +49,9 @@ public interface PairedSecurityKeyStorage {
      * @exception UnsupportedOperationException if this operation is not implemented.
      */
     Set<PairedSecurityKey> getAllPairedSecurityKeys();
+
+    /**
+     * Deletes a {@link PairedSecurityKey}.
+     */
+    void deletePairedSecurityKey(byte[] securityKeyAid);
 }


### PR DESCRIPTION
- Add manufacturer and serial number to `PairedSecurityKey` for display in the UI.
- Add `pairExistingKey()` function to get a `PairedSecurityKey` without wiping all data on the security key.
- Allow deleting keys from `PairedSecurityKeyStorage`.
- Fix a crash due to missing `PendingIntent` flags on API 31.